### PR TITLE
Use edit_resource on yum repos if they exist

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -57,6 +57,12 @@ module OslRepos
           false
         end
       end
+
+      def repo_resource_exist?(resource)
+        !find_resource!(:yum_repository, resource).nil?
+      rescue Chef::Exceptions::ResourceNotFound
+        false
+      end
     end
   end
 end

--- a/resources/centos.rb
+++ b/resources/centos.rb
@@ -79,7 +79,7 @@ action :add do
   # 'yum' will apply our changes to the main config file
   # 'yum-centos' install the remaining repositories and apply our configuration
   if repo_resource_exist?('base')
-    edit_resource!(:yum_globalconfig, '/etc/yum.conf') do
+    edit_resource(:yum_globalconfig, '/etc/yum.conf') do
       node['yum']['main'].each do |config, value|
         send(config.to_sym, value)
       end
@@ -87,7 +87,7 @@ action :add do
 
     node['yum-centos']['repos'].each do |repo|
       next unless node['yum'][repo]['managed']
-      edit_resource!(:yum_repository, repo) do
+      edit_resource(:yum_repository, repo) do
         node['yum'][repo].each do |config, value|
           case config
           when 'managed' # rubocop: disable Lint/EmptyWhen

--- a/resources/elrepo.rb
+++ b/resources/elrepo.rb
@@ -19,7 +19,7 @@ action :add do
   # Note: the elrepo repository is only availible for x86_64
   if new_resource.elrepo && platform?('centos') && node['kernel']['machine'] == 'x86_64'
     if repo_resource_exist?('elrepo')
-      edit_resource!(:yum_repository, 'elrepo') do
+      edit_resource(:yum_repository, 'elrepo') do
         node['yum']['elrepo'].each do |config, value|
           case config
           when 'managed' # rubocop: disable Lint/EmptyWhen

--- a/resources/elrepo.rb
+++ b/resources/elrepo.rb
@@ -18,6 +18,20 @@ action :add do
   # Include the yum-elrepo recipe, which will install the elrepo repository and apply our configuration
   # Note: the elrepo repository is only availible for x86_64
   if new_resource.elrepo && platform?('centos') && node['kernel']['machine'] == 'x86_64'
-    include_recipe 'yum-elrepo'
+    if repo_resource_exist?('elrepo')
+      edit_resource!(:yum_repository, 'elrepo') do
+        node['yum']['elrepo'].each do |config, value|
+          case config
+          when 'managed' # rubocop: disable Lint/EmptyWhen
+          when 'baseurl'
+            send(config.to_sym, lazy { value })
+          else
+            send(config.to_sym, value)
+          end
+        end
+      end
+    else
+      include_recipe 'yum-elrepo'
+    end
   end
 end

--- a/resources/epel.rb
+++ b/resources/epel.rb
@@ -25,7 +25,7 @@ action :add do
   if repo_resource_exist?('epel')
     node['yum-epel']['repos'].each do |repo|
       next unless node['yum'][repo]['managed']
-      edit_resource!(:yum_repository, repo) do
+      edit_resource(:yum_repository, repo) do
         node['yum'][repo].each do |config, value|
           case config
           when 'managed' # rubocop: disable Lint/EmptyWhen

--- a/resources/epel.rb
+++ b/resources/epel.rb
@@ -22,5 +22,22 @@ action :add do
   node.default['yum']['epel']['enabled'] = new_resource.epel
 
   # 'yum-epel' will install the epel repository and apply our configuration
-  include_recipe 'yum-epel'
+  if repo_resource_exist?('epel')
+    node['yum-epel']['repos'].each do |repo|
+      next unless node['yum'][repo]['managed']
+      edit_resource!(:yum_repository, repo) do
+        node['yum'][repo].each do |config, value|
+          case config
+          when 'managed' # rubocop: disable Lint/EmptyWhen
+          when 'baseurl'
+            send(config.to_sym, lazy { value })
+          else
+            send(config.to_sym, value)
+          end
+        end
+      end
+    end
+  else
+    include_recipe 'yum-epel'
+  end
 end


### PR DESCRIPTION
This fixes problems when using this in production where the yum, yum-centos, yum-epel and yum-centos recipes might be included in a community cookbook. If this happens, then the resources in this cookbook will fail to work and go back to the default settings.

By doing it this way, it ensures we get it correctly. This uses a similar logic used in the upstream cookbooks, but using `edit_resource` instead.
