### PR TITLE
Automatically remove pkg deps

### DIFF
--- a/resources/centos.rb
+++ b/resources/centos.rb
@@ -19,6 +19,7 @@ action :add do
   # Manage components of the main yum configuration file.
   node.default['yum']['main']['installonly_limit'] = '2'
   node.default['yum']['main']['installonlypkgs'] = 'kernel kernel-osuosl'
+  node.default['yum']['main']['clean_requirements_on_remove'] = true
 
   # Initialize all repo mirrorlists to nil
   node.default['yum']['appstream']['mirrorlist'] = nil

--- a/spec/unit/recipes/centos_spec.rb
+++ b/spec/unit/recipes/centos_spec.rb
@@ -39,7 +39,8 @@ describe 'osl-repos::centos' do
       it do
         expect(chef_run).to create_yum_globalconfig('/etc/yum.conf').with(
           installonly_limit: '2',
-          installonlypkgs: 'kernel kernel-osuosl'
+          installonlypkgs: 'kernel kernel-osuosl',
+          clean_requirements_on_remove: true
         )
       end
 

--- a/test/integration/centos/inspec/centos_spec.rb
+++ b/test/integration/centos/inspec/centos_spec.rb
@@ -2,6 +2,7 @@
 describe ini('/etc/yum.conf') do
   its('main.installonlypkgs') { should eq 'kernel kernel-osuosl' }
   its('main.installonly_limit') { should eq '2' }
+  its('main.clean_requirements_on_remove') { should eq 'true' }
 end
 
 arch = File.readlines('/proc/cpuinfo').grep(/POWER9/).any? ? 'power9' : os.arch


### PR DESCRIPTION
By default, CentOS does not remove dependant packages when you remove a specific package. This enables it by default and will be useful for when we remove munin from all of our nodes.
