### PR TITLE
Directly use yum_globalconfig resource

### DIFF
--- a/resources/centos.rb
+++ b/resources/centos.rb
@@ -17,9 +17,16 @@ property :highavailability, [true, false], default: false
 # This is the default and only action it will manage all repos listed above and enable them as indicated
 action :add do
   # Manage components of the main yum configuration file.
-  node.default['yum']['main']['installonly_limit'] = '2'
-  node.default['yum']['main']['installonlypkgs'] = 'kernel kernel-osuosl'
-  node.default['yum']['main']['clean_requirements_on_remove'] = true
+  yum_globalconfig '/etc/yum.conf' do
+    if node['platform_version'].to_i < 8
+      distroverpkg 'centos-release'
+    else
+      cachedir '/var/cache/dnf'
+    end
+    installonly_limit '2'
+    installonlypkgs 'kernel kernel-osuosl'
+    clean_requirements_on_remove true
+  end
 
   # Initialize all repo mirrorlists to nil
   node.default['yum']['appstream']['mirrorlist'] = nil
@@ -101,7 +108,6 @@ action :add do
       end
     end
   else
-    include_recipe 'yum'
     include_recipe 'yum-centos'
   end
 end

--- a/spec/unit/recipes/centos_spec.rb
+++ b/spec/unit/recipes/centos_spec.rb
@@ -35,17 +35,16 @@ describe 'osl-repos::centos' do
         expect { chef_run }.to_not raise_error
       end
 
-      # Test for the main configuration file ('/etc/yum.conf'cookstyle)
-      it do
-        expect(chef_run).to create_yum_globalconfig('/etc/yum.conf').with(
-          installonly_limit: '2',
-          installonlypkgs: 'kernel kernel-osuosl',
-          clean_requirements_on_remove: true
-        )
-      end
-
       case p[:version].to_i
       when 7
+        it do
+          expect(chef_run).to create_yum_globalconfig('/etc/yum.conf').with(
+            distroverpkg: 'centos-release',
+            installonly_limit: '2',
+            installonlypkgs: 'kernel kernel-osuosl',
+            clean_requirements_on_remove: true
+          )
+        end
 
         # We need to test each supported architecture
         # This loop creates a context for each architecture and applies its tests.
@@ -180,6 +179,14 @@ describe 'osl-repos::centos' do
         end
 
       when 8
+        it do
+          expect(chef_run).to create_yum_globalconfig('/etc/yum.conf').with(
+            cachedir: '/var/cache/dnf',
+            installonly_limit: '2',
+            installonlypkgs: 'kernel kernel-osuosl',
+            clean_requirements_on_remove: true
+          )
+        end
 
         # We need to test each supported architecture
         # This loop creates a context for each architecture and applies its tests.

--- a/test/integration/centos/inspec/centos_spec.rb
+++ b/test/integration/centos/inspec/centos_spec.rb
@@ -1,14 +1,14 @@
-# Test for the main configuration file ('/etc/yum.conf'cookstyle)
-describe ini('/etc/yum.conf') do
-  its('main.installonlypkgs') { should eq 'kernel kernel-osuosl' }
-  its('main.installonly_limit') { should eq '2' }
-  its('main.clean_requirements_on_remove') { should eq 'true' }
-end
-
 arch = File.readlines('/proc/cpuinfo').grep(/POWER9/).any? ? 'power9' : os.arch
 case os.release.to_i
 
 when 7
+  describe ini('/etc/yum.conf') do
+    its('main.distroverpkg') { should eq 'centos-release' }
+    its('main.cachedir') { should eq '/var/cache/yum/$basearch/$releasever' }
+    its('main.installonlypkgs') { should eq 'kernel kernel-osuosl' }
+    its('main.installonly_limit') { should eq '2' }
+    its('main.clean_requirements_on_remove') { should eq 'true' }
+  end
 
   centos_url = arch == 'x86_64' ? 'https://centos.osuosl.org' : 'https://centos-altarch.osuosl.org'
 
@@ -37,6 +37,13 @@ when 7
   end
 
 when 8
+  describe ini('/etc/yum.conf') do
+    its('main.distroverpkg') { should eq nil }
+    its('main.cachedir') { should eq '/var/cache/dnf' }
+    its('main.installonlypkgs') { should eq 'kernel kernel-osuosl' }
+    its('main.installonly_limit') { should eq '2' }
+    its('main.clean_requirements_on_remove') { should eq 'true' }
+  end
 
   # Test the appstream repository
   describe yum.repo('appstream') do


### PR DESCRIPTION
This fixes an issue with attribute precedence on our production nodes where simply including the yum::default recipe doesn't actually create the config we expect.

This also fixes a few minor issues on EL8 nodes (which needs to be fixed upstream but we'll do that later).
