### PR TITLE
Fix issues with yum_repository resources not working

### DIFF
--- a/resources/centos.rb
+++ b/resources/centos.rb
@@ -87,7 +87,7 @@ action :add do
   # 'yum' will apply our changes to the main config file
   # 'yum-centos' install the remaining repositories and apply our configuration
   if repo_resource_exist?('base')
-    edit_resource(:yum_globalconfig, '/etc/yum.conf') do
+    declare_resource(:yum_globalconfig, '/etc/yum.conf') do
       node['yum']['main'].each do |config, value|
         send(config.to_sym, value)
       end
@@ -95,7 +95,7 @@ action :add do
 
     node['yum-centos']['repos'].each do |repo|
       next unless node['yum'][repo]['managed']
-      edit_resource(:yum_repository, repo) do
+      declare_resource(:yum_repository, repo) do
         node['yum'][repo].each do |config, value|
           case config
           when 'managed' # rubocop: disable Lint/EmptyWhen

--- a/resources/elrepo.rb
+++ b/resources/elrepo.rb
@@ -19,7 +19,7 @@ action :add do
   # Note: the elrepo repository is only availible for x86_64
   if new_resource.elrepo && platform?('centos') && node['kernel']['machine'] == 'x86_64'
     if repo_resource_exist?('elrepo')
-      edit_resource(:yum_repository, 'elrepo') do
+      declare_resource(:yum_repository, 'elrepo') do
         node['yum']['elrepo'].each do |config, value|
           case config
           when 'managed' # rubocop: disable Lint/EmptyWhen

--- a/resources/epel.rb
+++ b/resources/epel.rb
@@ -25,7 +25,7 @@ action :add do
   if repo_resource_exist?('epel')
     node['yum-epel']['repos'].each do |repo|
       next unless node['yum'][repo]['managed']
-      edit_resource(:yum_repository, repo) do
+      declare_resource(:yum_repository, repo) do
         node['yum'][repo].each do |config, value|
           case config
           when 'managed' # rubocop: disable Lint/EmptyWhen


### PR DESCRIPTION
This works around an issue we're running into where the various `yum_repository` resources we edit are not properly being run in the order we expect. Instead of using `edit_resource`, we should be using `declare_resource` which will ensure the resource is executed at the time we call these custom resources.
