### PR TITLE
Use declare_resource correctly

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -63,6 +63,55 @@ module OslRepos
       rescue Chef::Exceptions::ResourceNotFound
         false
       end
+
+      # List all known parameters for yum_repository
+      # https://docs.chef.io/resources/yum_repository/
+      def yum_repo_parameters
+        %w(
+          baseurl
+          clean_metadata
+          cost
+          description
+          enabled
+          enablegroups
+          exclude
+          failovermethod
+          fastestmirror_enabled
+          gpgcheck
+          gpgkey
+          http_caching
+          include_config
+          includepkgs
+          keepalive
+          make_cache
+          max_retries
+          metadata_expire
+          metalink
+          mirror_expire
+          mirrorlist
+          mirrorlist_expire
+          mode
+          options
+          password
+          priority
+          proxy
+          proxy_password
+          proxy_username
+          repo_gpgcheck
+          report_instanceid
+          reposdir
+          repositoryid
+          skip_if_unavailable
+          source
+          sslcacert
+          sslclientcert
+          sslclientkey
+          sslverify
+          throttle
+          timeout
+          username
+        )
+      end
     end
   end
 end

--- a/resources/epel.rb
+++ b/resources/epel.rb
@@ -11,33 +11,48 @@ property :epel_enabled, [true, false], default: true
 
 # This is the default and only action, It will add all available repos, unless specified in properties above
 action :add do
-  node.default['yum']['epel']['mirrorlist'] = nil
-  node.default['yum']['epel']['baseurl'] = epel_baseurl
-  node.default['yum']['epel']['gpgkey'] = "https://epel.osuosl.org/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}"
+  # Initialize run state attributes
+  node.run_state['epel'] ||= {}
+  node.run_state['epel']['mirrorlist'] ||= {}
+  node.run_state['epel']['baseurl'] ||= {}
+  node.run_state['epel']['gpgkey'] ||= {}
+
+  node.run_state['epel']['mirrorlist'] = nil
+  node.run_state['epel']['baseurl'] = epel_baseurl
+  node.run_state['epel']['gpgkey'] = "https://epel.osuosl.org/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}"
 
   # Determine if the repository is managed
   node.default['yum']['epel']['managed'] = true unless node['kernel']['machine'] == 's390x'
 
   # Determine if the repository is enabled
-  node.default['yum']['epel']['enabled'] = new_resource.epel
+  node.run_state['epel']['enabled'] = new_resource.epel
 
   # 'yum-epel' will install the epel repository and apply our configuration
   if repo_resource_exist?('epel')
     node['yum-epel']['repos'].each do |repo|
       next unless node['yum'][repo]['managed']
+      # Find the resource and update each parameter we need changed
+      r = resources(yum_repository: repo)
+      node.run_state[repo].each do |config, value|
+        r.send(config.to_sym, value)
+      end
+
+      # Declare the resource with all parameters that are either used in yum-centos or we set in our cookbooks
       declare_resource(:yum_repository, repo) do
-        node['yum'][repo].each do |config, value|
-          case config
-          when 'managed' # rubocop: disable Lint/EmptyWhen
-          when 'baseurl'
-            send(config.to_sym, lazy { value })
-          else
-            send(config.to_sym, value)
-          end
+        yum_repo_parameters.each do |p|
+          send(p.to_sym, r.send(p.to_sym))
         end
       end
     end
   else
+    # Copy all run state attributes to global node.default realm
+    node['yum-epel']['repos'].each do |repo|
+      next unless node['yum'][repo]['managed']
+      node.run_state[repo].each do |config, value|
+        node.default['yum'][repo][config] = value
+      end
+    end
+
     include_recipe 'yum-epel'
   end
 end


### PR DESCRIPTION
This properly uses `declare_resource` by doing the following:

- Move all parameter settings we need changed to `node.run_state` [1] so we can loop _only_ the parameters we need changed easily
- Find the specific `yum_repository` resource and change each parameter we set in `node.run_state`. This ensures we pull any other `edit_resource` changes to these resources at compile time and pull them in.
- Declare the whole resource again looping through all known parameters for `yum_repository`
- Set all `node.default` attributes we had set in `node.run_state` so it can be used with the recipes if the resource hasn't been defined.

This basically resolves an issue where changes made to the resource after this gets called gets changed again and causes idempotency issues.

Of course, most of this can go away if proper resources for each repositories are created but this is unfortunately what we need to do to work around attributes.

[1] https://docs.chef.io/recipes/#noderun_state
