### PR TITLE
Update `yum` version pin to support Chef 17

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,7 @@ source_url        'https://github.com/osuosl-cookbooks/osl-repos'
 chef_version      '>= 16.0'
 version           '1.2.0'
 
-depends           'yum',          '~> 5.1.0'
+depends           'yum',          '~> 7.2.0'
 depends           'yum-centos',   '~> 4.0'
 depends           'yum-epel',     '~> 3.3.0'
 depends           'yum-elrepo',   '~> 2.0.0'


### PR DESCRIPTION
Will be part of the suite of `base` updates, don't merge until then