### PR TITLE
Update yum pin to 7.3

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,7 @@ source_url        'https://github.com/osuosl-cookbooks/osl-repos'
 chef_version      '>= 16.0'
 version           '2.0.0'
 
-depends           'yum',          '~> 7.2.0'
+depends           'yum',          '~> 7.3.0'
 depends           'yum-centos',   '~> 5.2.0'
 depends           'yum-epel',     '~> 4.2.3'
 depends           'yum-elrepo',   '~> 2.0.0'

--- a/recipes/centos.rb
+++ b/recipes/centos.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos
 # Recipe:: centos
 #
-# Copyright:: 2020-2021, Oregon State University
+# Copyright:: 2020-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/elrepo.rb
+++ b/recipes/elrepo.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos
 # Recipe:: elrepo
 #
-# Copyright:: 2020-2021, Oregon State University
+# Copyright:: 2020-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/epel.rb
+++ b/recipes/epel.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos
 # Recipe:: epel
 #
-# Copyright:: 2020-2021, Oregon State University
+# Copyright:: 2020-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/recipes/centos_spec.rb
+++ b/spec/unit/recipes/centos_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos
 # Spec:: default
 #
-# Copyright:: 2020-2021, Oregon State University
+# Copyright:: 2020-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/recipes/disable_spec.rb
+++ b/spec/unit/recipes/disable_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos-test
 # Spec:: disable
 #
-# Copyright:: 2020-2021, Oregon State University
+# Copyright:: 2020-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/recipes/elrepo_spec.rb
+++ b/spec/unit/recipes/elrepo_spec.rb
@@ -1,7 +1,7 @@
 # Cookbook:: osl-repos
 # Spec:: elrepo
 #
-# Copyright:: 2020-2021, Oregon State University
+# Copyright:: 2020-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/recipes/epel_spec.rb
+++ b/spec/unit/recipes/epel_spec.rb
@@ -1,7 +1,7 @@
 # Cookbook:: osl-repos
 # Spec:: epel
 #
-# Copyright:: 2020-2021, Oregon State University
+# Copyright:: 2020-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/recipes/highavailability_spec.rb
+++ b/spec/unit/recipes/highavailability_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos-test
 # Spec:: highavailability
 #
-# Copyright:: 2020-2021, Oregon State University
+# Copyright:: 2020-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/recipes/with_edit_spec.rb
+++ b/spec/unit/recipes/with_edit_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos-test
 # Spec:: with_edit
 #
-# Copyright:: 2020-2021, Oregon State University
+# Copyright:: 2020-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/cookbooks/osl-repos-test/recipes/disable.rb
+++ b/test/cookbooks/osl-repos-test/recipes/disable.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos
 # Recipe:: disable
 #
-# Copyright:: 2020-2021, Oregon State University
+# Copyright:: 2020-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/cookbooks/osl-repos-test/recipes/highavailability.rb
+++ b/test/cookbooks/osl-repos-test/recipes/highavailability.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos
 # Recipe:: highavailability
 #
-# Copyright:: 2020-2021, Oregon State University
+# Copyright:: 2020-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/cookbooks/osl-repos-test/recipes/with_edit.rb
+++ b/test/cookbooks/osl-repos-test/recipes/with_edit.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos
 # Recipe:: with_edit
 #
-# Copyright:: 2020-2021, Oregon State University
+# Copyright:: 2020-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This includes the new cache flush from sous-chefs/yum#196 required for the Remi PHP modules in osuosl-cookbooks/osl-php#52.