### PR TITLE
Add exclude property to resources

### DIFF
--- a/resources/elrepo.rb
+++ b/resources/elrepo.rb
@@ -6,6 +6,7 @@ default_action :add
 
 # This property indicates whether the elrepo repo should be enabled
 property :elrepo, [true, false], default: true
+property :exclude, Array, default: []
 
 # This is the default and only action, It will add all available repos, unless specified in properties above
 action :add do
@@ -16,6 +17,7 @@ action :add do
 
   node.run_state['elrepo']['mirrorlist'] = nil
   node.run_state['elrepo']['baseurl'] = 'https://ftp.osuosl.org/pub/elrepo/elrepo/el$releasever/$basearch/'
+  node.run_state['elrepo']['exclude'] = new_resource.exclude.join(' ') unless new_resource.exclude.empty?
 
   node.default['yum']['elrepo']['managed'] = true
 

--- a/resources/epel.rb
+++ b/resources/epel.rb
@@ -9,6 +9,7 @@ property :epel, [true, false], default: true
 
 # This property indicates whether or not the epel repo should be enabled
 property :epel_enabled, [true, false], default: true
+property :exclude, Array, default: []
 
 # This is the default and only action, It will add all available repos, unless specified in properties above
 action :add do
@@ -21,6 +22,7 @@ action :add do
   node.run_state['epel']['mirrorlist'] = nil
   node.run_state['epel']['baseurl'] = epel_baseurl
   node.run_state['epel']['gpgkey'] = "https://epel.osuosl.org/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}"
+  node.run_state['epel']['exclude'] = new_resource.exclude.join(' ') unless new_resource.exclude.empty?
 
   # CentOS Stream
   node.run_state['epel-next'] ||= {}

--- a/spec/unit/recipes/centos_spec.rb
+++ b/spec/unit/recipes/centos_spec.rb
@@ -70,6 +70,7 @@ describe 'osl-repos::centos' do
               it do
                 expect(chef_run).to create_yum_repository('base').with(
                   mirrorlist: nil,
+                  exclude: nil,
                   baseurl: 'https://centos-altarch.osuosl.org/$releasever/os/$basearch/',
                   gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-7-$basearch',
                   enabled: true
@@ -80,6 +81,7 @@ describe 'osl-repos::centos' do
               it do
                 expect(chef_run).to create_yum_repository('extras').with(
                   mirrorlist: nil,
+                  exclude: nil,
                   baseurl: 'https://centos-altarch.osuosl.org/$releasever/extras/$basearch/',
                   gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-7-$basearch',
                   enabled: true
@@ -90,6 +92,7 @@ describe 'osl-repos::centos' do
               it do
                 expect(chef_run).to create_yum_repository('updates').with(
                   mirrorlist: nil,
+                  exclude: nil,
                   baseurl: 'https://centos-altarch.osuosl.org/$releasever/updates/$basearch/',
                   gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-7-$basearch',
                   enabled: true
@@ -102,6 +105,7 @@ describe 'osl-repos::centos' do
               it do
                 expect(chef_run).to create_yum_repository('base').with(
                   mirrorlist: nil,
+                  exclude: nil,
                   baseurl: 'https://centos.osuosl.org/$releasever/os/$basearch/',
                   gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7',
                   enabled: true
@@ -112,6 +116,7 @@ describe 'osl-repos::centos' do
               it do
                 expect(chef_run).to create_yum_repository('extras').with(
                   mirrorlist: nil,
+                  exclude: nil,
                   baseurl: 'https://centos.osuosl.org/$releasever/extras/$basearch/',
                   gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7',
                   enabled: true
@@ -122,6 +127,7 @@ describe 'osl-repos::centos' do
               it do
                 expect(chef_run).to create_yum_repository('updates').with(
                   mirrorlist: nil,
+                  exclude: nil,
                   baseurl: 'https://centos.osuosl.org/$releasever/updates/$basearch/',
                   gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7',
                   enabled: true

--- a/spec/unit/recipes/elrepo_spec.rb
+++ b/spec/unit/recipes/elrepo_spec.rb
@@ -50,6 +50,7 @@ describe 'osl-repos::elrepo' do
               it do
                 expect(chef_run).to create_yum_repository('elrepo').with(
                   mirrorlist: nil,
+                  exclude: nil,
                   baseurl: 'https://ftp.osuosl.org/pub/elrepo/elrepo/el$releasever/$basearch/',
                   enabled: true
                 )
@@ -101,6 +102,7 @@ describe 'osl-repos::elrepo' do
               it do
                 expect(chef_run).to create_yum_repository('elrepo').with(
                   mirrorlist: nil,
+                  exclude: nil,
                   baseurl: 'https://ftp.osuosl.org/pub/elrepo/elrepo/el$releasever/$basearch/',
                   enabled: true
                 )

--- a/spec/unit/recipes/epel_spec.rb
+++ b/spec/unit/recipes/epel_spec.rb
@@ -38,6 +38,7 @@ describe 'osl-repos::epel' do
         it do
           expect(chef_run).to create_yum_repository('epel').with(
             mirrorlist: nil,
+            exclude: nil,
             baseurl: 'https://epel.osuosl.org/$releasever/$basearch/',
             gpgkey: 'https://epel.osuosl.org/RPM-GPG-KEY-EPEL-7',
             enabled: true
@@ -49,6 +50,7 @@ describe 'osl-repos::epel' do
         it do
           expect(chef_run).to create_yum_repository('epel').with(
             mirrorlist: nil,
+            exclude: nil,
             baseurl: 'https://epel.osuosl.org/$releasever/Everything/$basearch/',
             gpgkey: 'https://epel.osuosl.org/RPM-GPG-KEY-EPEL-8',
             enabled: true

--- a/spec/unit/recipes/with_edit_spec.rb
+++ b/spec/unit/recipes/with_edit_spec.rb
@@ -70,6 +70,7 @@ describe 'osl-repos-test::with_edit' do
               it do
                 expect(chef_run).to create_yum_repository('base').with(
                   mirrorlist: nil,
+                  exclude: 'foo bar',
                   baseurl: 'https://centos-altarch.osuosl.org/$releasever/os/$basearch/',
                   gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-7-$basearch',
                   enabled: true
@@ -80,6 +81,7 @@ describe 'osl-repos-test::with_edit' do
               it do
                 expect(chef_run).to create_yum_repository('extras').with(
                   mirrorlist: nil,
+                  exclude: 'foo bar',
                   baseurl: 'https://centos-altarch.osuosl.org/$releasever/extras/$basearch/',
                   gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-7-$basearch',
                   enabled: false
@@ -90,6 +92,7 @@ describe 'osl-repos-test::with_edit' do
               it do
                 expect(chef_run).to create_yum_repository('updates').with(
                   mirrorlist: nil,
+                  exclude: 'foo bar',
                   baseurl: 'https://centos-altarch.osuosl.org/$releasever/updates/$basearch/',
                   gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-7-$basearch',
                   enabled: false
@@ -104,6 +107,7 @@ describe 'osl-repos-test::with_edit' do
               it do
                 expect(chef_run).to create_yum_repository('base').with(
                   mirrorlist: nil,
+                  exclude: 'foo bar',
                   baseurl: 'https://centos.osuosl.org/$releasever/os/$basearch/',
                   gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7',
                   enabled: true
@@ -114,6 +118,7 @@ describe 'osl-repos-test::with_edit' do
               it do
                 expect(chef_run).to create_yum_repository('extras').with(
                   mirrorlist: nil,
+                  exclude: 'foo bar',
                   baseurl: 'https://centos.osuosl.org/$releasever/extras/$basearch/',
                   gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7',
                   enabled: false
@@ -124,6 +129,7 @@ describe 'osl-repos-test::with_edit' do
               it do
                 expect(chef_run).to create_yum_repository('updates').with(
                   mirrorlist: nil,
+                  exclude: 'foo bar',
                   baseurl: 'https://centos.osuosl.org/$releasever/updates/$basearch/',
                   gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7',
                   enabled: false
@@ -152,6 +158,7 @@ describe 'osl-repos-test::with_edit' do
             it do
               expect(chef_run).to create_yum_repository('base').with(
                 mirrorlist: nil,
+                exclude: 'foo bar',
                 baseurl: "https://centos-altarch.osuosl.org/$releasever/os/#{base_arch}/",
                 gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-7-$basearch',
                 enabled: true
@@ -162,6 +169,7 @@ describe 'osl-repos-test::with_edit' do
             it do
               expect(chef_run).to create_yum_repository('extras').with(
                 mirrorlist: nil,
+                exclude: 'foo bar',
                 baseurl: "https://centos-altarch.osuosl.org/$releasever/extras/#{base_arch}/",
                 gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-7-$basearch',
                 enabled: false
@@ -172,6 +180,7 @@ describe 'osl-repos-test::with_edit' do
             it do
               expect(chef_run).to create_yum_repository('updates').with(
                 mirrorlist: nil,
+                exclude: 'foo bar',
                 baseurl: "https://centos-altarch.osuosl.org/$releasever/updates/#{base_arch}/",
                 gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-AltArch-7-$basearch',
                 enabled: false
@@ -199,6 +208,7 @@ describe 'osl-repos-test::with_edit' do
             it do
               expect(chef_run).to create_yum_repository('appstream').with(
                 mirrorlist: nil,
+                exclude: 'foo bar',
                 baseurl: 'https://centos.osuosl.org/$releasever/AppStream/$basearch/os/',
                 enabled: false
               )
@@ -208,6 +218,7 @@ describe 'osl-repos-test::with_edit' do
             it do
               expect(chef_run).to create_yum_repository('base').with(
                 mirrorlist: nil,
+                exclude: 'foo bar',
                 baseurl: 'https://centos.osuosl.org/$releasever/BaseOS/$basearch/os/',
                 enabled: true
               )
@@ -217,6 +228,7 @@ describe 'osl-repos-test::with_edit' do
             it do
               expect(chef_run).to create_yum_repository('extras').with(
                 mirrorlist: nil,
+                exclude: 'foo bar',
                 baseurl: 'https://centos.osuosl.org/$releasever/extras/$basearch/os/',
                 enabled: false
               )
@@ -226,6 +238,7 @@ describe 'osl-repos-test::with_edit' do
             it do
               expect(chef_run).to create_yum_repository('highavailability').with(
                 mirrorlist: nil,
+                exclude: 'foo bar',
                 baseurl: 'https://centos.osuosl.org/$releasever/HighAvailability/$basearch/os/',
                 enabled: false
               )
@@ -235,6 +248,7 @@ describe 'osl-repos-test::with_edit' do
             it do
               expect(chef_run).to create_yum_repository('powertools').with(
                 mirrorlist: nil,
+                exclude: 'foo bar',
                 baseurl: 'https://centos.osuosl.org/$releasever/PowerTools/$basearch/os/',
                 enabled: false
               )
@@ -258,6 +272,7 @@ describe 'osl-repos-test::with_edit' do
             it do
               expect(chef_run).to create_yum_repository('appstream').with(
                 mirrorlist: nil,
+                exclude: 'foo bar',
                 baseurl: 'https://centos.osuosl.org/$releasever/AppStream/$basearch/os/',
                 enabled: false
               )
@@ -267,6 +282,7 @@ describe 'osl-repos-test::with_edit' do
             it do
               expect(chef_run).to create_yum_repository('base').with(
                 mirrorlist: nil,
+                exclude: 'foo bar',
                 baseurl: 'https://centos.osuosl.org/$releasever/BaseOS/$basearch/os/',
                 enabled: true
               )
@@ -276,6 +292,7 @@ describe 'osl-repos-test::with_edit' do
             it do
               expect(chef_run).to create_yum_repository('extras').with(
                 mirrorlist: nil,
+                exclude: 'foo bar',
                 baseurl: 'https://centos.osuosl.org/$releasever/extras/$basearch/os/',
                 enabled: false
               )
@@ -285,6 +302,7 @@ describe 'osl-repos-test::with_edit' do
             it do
               expect(chef_run).to create_yum_repository('highavailability').with(
                 mirrorlist: nil,
+                exclude: 'foo bar',
                 baseurl: 'https://centos.osuosl.org/$releasever/HighAvailability/$basearch/os/',
                 enabled: false
               )
@@ -294,6 +312,7 @@ describe 'osl-repos-test::with_edit' do
             it do
               expect(chef_run).to create_yum_repository('powertools').with(
                 mirrorlist: nil,
+                exclude: 'foo bar',
                 baseurl: 'https://centos.osuosl.org/$releasever/PowerTools/$basearch/os/',
                 enabled: false
               )

--- a/test/cookbooks/osl-repos-test/recipes/with_edit.rb
+++ b/test/cookbooks/osl-repos-test/recipes/with_edit.rb
@@ -24,4 +24,5 @@ edit_resource(:osl_repos_centos, 'default') do
   extras false
   powertools false
   updates false
+  exclude %w(foo bar)
 end


### PR DESCRIPTION
This is useful when you need to exclude certain packages from a repository. This is currently needed in osl-openstack but will be useful elsewhere.

Signed-off-by: Lance Albertson <lance@osuosl.org>
