### PR TITLE
Add osl_repos_centos_kmods resource

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -18,6 +18,12 @@ suites:
     includes:
       - almalinux-8
       - almalinux-9
+  - name: centos-kmods
+    run_list:
+      - recipe[osl-repos-test::centos_kmods]
+    includes:
+      - almalinux-8
+      - almalinux-9
   - name: debian
     run_list:
       - recipe[osl-repos::debian]

--- a/resources/centos_kmods.rb
+++ b/resources/centos_kmods.rb
@@ -1,0 +1,51 @@
+resource_name :osl_repos_centos_kmods
+provides :osl_repos_centos_kmods
+default_action :add
+unified_mode true
+
+property :kernel_latest, [true, false], default: false
+property :kernel_6_1, [true, false], default: false
+property :kernel_6_6, [true, false], default: false
+property :packages_main, [true, false], default: true
+property :packages_rebuild, [true, false], default: false
+property :packages_userspace, [true, false], default: false
+
+action :add do
+  raise 'CentOS Kmods repositories are for RHEL systems only' unless platform_family?('rhel')
+
+  yum_repository 'centos-kmods' do
+    description 'CentOS $releasever - Kmods'
+    baseurl 'https://centos-stream.osuosl.org/SIGs/$releasever/kmods/$basearch/packages-main/'
+    gpgkey 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Kmods'
+  end if new_resource.packages_main
+
+  yum_repository 'centos-kmods-rebuild' do
+    description 'CentOS $releasever - Kmods - Rebuild'
+    baseurl 'https://centos-stream.osuosl.org/SIGs/$releasever/kmods/$basearch/packages-rebuild/'
+    gpgkey 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Kmods'
+  end if new_resource.packages_rebuild
+
+  yum_repository 'centos-kmods-userspace' do
+    description 'CentOS $releasever - Kmods - User Space'
+    baseurl 'https://centos-stream.osuosl.org/SIGs/$releasever/kmods/$basearch/packages-userspace/'
+    gpgkey 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Kmods'
+  end if new_resource.packages_userspace
+
+  yum_repository 'centos-kmods-kernel-latest' do
+    description 'CentOS $releasever - Kmods - Kernel'
+    baseurl 'https://centos-stream.osuosl.org/SIGs/$releasever/kmods/$basearch/kernel-latest/'
+    gpgkey 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Kmods'
+  end if new_resource.kernel_latest && node['platform_version'].to_i >= 9
+
+  yum_repository 'centos-kmods-kernel-6.1' do
+    description 'CentOS $releasever - Kmods - Kernel - 6.1'
+    baseurl 'https://centos-stream.osuosl.org/SIGs/$releasever/kmods/$basearch/kernel-6.1/'
+    gpgkey 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Kmods'
+  end if new_resource.kernel_6_1
+
+  yum_repository 'centos-kmods-kernel-6.6' do
+    description 'CentOS $releasever - Kmods - Kernel - 6.6'
+    baseurl 'https://centos-stream.osuosl.org/SIGs/$releasever/kmods/$basearch/kernel-6.6/'
+    gpgkey 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Kmods'
+  end if new_resource.kernel_6_6
+end

--- a/spec/unit/recipes/centos_kmods_spec.rb
+++ b/spec/unit/recipes/centos_kmods_spec.rb
@@ -1,0 +1,93 @@
+#
+# Cookbook:: osl-repos
+# Spec:: centos_kmods
+#
+# Copyright:: 2024, Oregon State University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative '../../spec_helper'
+
+# Begin Spec Tests
+describe 'osl-repos-test::centos_kmods' do
+  [ALMA_8, ALMA_9].each do |p|
+    context "#{p[:platform]} #{p[:version]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(p.dup.merge(step_into: :osl_repos_centos_kmods)).converge(described_recipe)
+      end
+
+      # Check for convergence
+      it 'converges successfully' do
+        expect { chef_run }.to_not raise_error
+      end
+
+      it do
+        is_expected.to create_yum_repository('centos-kmods').with(
+          description: 'CentOS $releasever - Kmods',
+          url: 'https://centos-stream.osuosl.org/SIGs/$releasever/kmods/$basearch/packages-main/',
+          gpgcheck: true,
+          gpgkey: 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Kmods'
+        )
+      end
+
+      it do
+        is_expected.to create_yum_repository('centos-kmods-rebuild').with(
+          description: 'CentOS $releasever - Kmods - Rebuild',
+          url: 'https://centos-stream.osuosl.org/SIGs/$releasever/kmods/$basearch/packages-rebuild/',
+          gpgcheck: true,
+          gpgkey: 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Kmods'
+        )
+      end
+
+      it do
+        is_expected.to create_yum_repository('centos-kmods-userspace').with(
+          description: 'CentOS $releasever - Kmods - User Space',
+          url: 'https://centos-stream.osuosl.org/SIGs/$releasever/kmods/$basearch/packages-userspace/',
+          gpgcheck: true,
+          gpgkey: 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Kmods'
+        )
+      end
+
+      it do
+        is_expected.to create_yum_repository('centos-kmods-kernel-6.1').with(
+          description: 'CentOS $releasever - Kmods - Kernel - 6.1',
+          url: 'https://centos-stream.osuosl.org/SIGs/$releasever/kmods/$basearch/kernel-6.1/',
+          gpgcheck: true,
+          gpgkey: 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Kmods'
+        )
+      end
+
+      it do
+        is_expected.to create_yum_repository('centos-kmods-kernel-6.6').with(
+          description: 'CentOS $releasever - Kmods - Kernel - 6.6',
+          url: 'https://centos-stream.osuosl.org/SIGs/$releasever/kmods/$basearch/kernel-6.6/',
+          gpgcheck: true,
+          gpgkey: 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Kmods'
+        )
+      end
+
+      if p[:version].to_i >= 9
+        it do
+          is_expected.to create_yum_repository('centos-kmods-kernel-latest').with(
+            description: 'CentOS $releasever - Kmods - Kernel',
+            url: 'https://centos-stream.osuosl.org/SIGs/$releasever/kmods/$basearch/kernel-latest/',
+            gpgcheck: true,
+            gpgkey: 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Kmods'
+          )
+        end
+      else
+        it { is_expected.to_not create_yum_repository 'centos-kmods-kernel-latest' }
+      end
+    end
+  end
+end

--- a/test/cookbooks/osl-repos-test/recipes/centos_kmods.rb
+++ b/test/cookbooks/osl-repos-test/recipes/centos_kmods.rb
@@ -1,0 +1,7 @@
+osl_repos_centos_kmods 'default' do
+  kernel_latest true
+  kernel_6_1 true
+  kernel_6_6 true
+  packages_rebuild true
+  packages_userspace true
+end

--- a/test/integration/centos-kmods/controls/centos_kmods_control.rb
+++ b/test/integration/centos-kmods/controls/centos_kmods_control.rb
@@ -1,0 +1,75 @@
+control 'elevate' do
+  title 'Verify centos-kmods yum repos are configured'
+
+  rel = os[:release].to_i
+  arch = os[:arch]
+
+  describe yum.repo('centos-kmods') do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') { should include "https://centos-stream.osuosl.org/SIGs/#{rel}/kmods/#{arch}/packages-main/" }
+  end
+
+  describe yum.repo('centos-kmods-rebuild') do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') { should include "https://centos-stream.osuosl.org/SIGs/#{rel}/kmods/#{arch}/packages-rebuild/" }
+  end
+
+  describe yum.repo('centos-kmods-userspace') do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') { should include "https://centos-stream.osuosl.org/SIGs/#{rel}/kmods/#{arch}/packages-userspace/" }
+  end
+
+  describe yum.repo('centos-kmods-kernel-6.1') do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') { should include "https://centos-stream.osuosl.org/SIGs/#{rel}/kmods/#{arch}/kernel-6.1/" }
+  end
+
+  describe yum.repo('centos-kmods-kernel-6.6') do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') { should include "https://centos-stream.osuosl.org/SIGs/#{rel}/kmods/#{arch}/kernel-6.6/" }
+  end
+
+  %w(
+    centos-kmods
+    centos-kmods-rebuild
+    centos-kmods-userspace
+  ).each do |r|
+    describe ini("/etc/yum.repos.d/#{r}.repo") do
+      its("#{r}.gpgcheck") { should cmp '1' }
+      its("#{r}.gpgkey") { should cmp 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Kmods' }
+    end
+  end
+
+  describe ini('/etc/yum.repos.d/centos-kmods-kernel-6.1.repo') do
+    its(['centos-kmods-kernel-6.1', 'gpgcheck']) { should cmp '1' }
+    its(['centos-kmods-kernel-6.1', 'gpgkey']) { should cmp 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Kmods' }
+  end
+
+  describe ini('/etc/yum.repos.d/centos-kmods-kernel-6.6.repo') do
+    its(['centos-kmods-kernel-6.6', 'gpgcheck']) { should cmp '1' }
+    its(['centos-kmods-kernel-6.6', 'gpgkey']) { should cmp 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Kmods' }
+  end
+
+  if rel >= 9
+    describe ini('/etc/yum.repos.d/centos-kmods-kernel-latest.repo') do
+      its('centos-kmods-kernel-latest.gpgcheck') { should cmp '1' }
+      its('centos-kmods-kernel-latest.gpgkey') { should cmp 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Kmods' }
+    end
+
+    describe yum.repo('centos-kmods-kernel-latest') do
+      it { should exist }
+      it { should be_enabled }
+      its('baseurl') { should include "https://centos-stream.osuosl.org/SIGs/#{rel}/kmods/#{arch}/kernel-latest/" }
+    end
+  else
+    describe yum.repo('centos-kmods-kernel-latest') do
+      it { should_not exist }
+      it { should_not be_enabled }
+    end
+  end
+end

--- a/test/integration/centos-kmods/inspec.yml
+++ b/test/integration/centos-kmods/inspec.yml
@@ -1,0 +1,2 @@
+---
+name: centos-kmods


### PR DESCRIPTION
This is needed so that we can install the 6.6 kernel to get PCI-passthru working
for the OPF HUB.

Signed-off-by: Lance Albertson <lance@osuosl.org>
