### PR TITLE
Rename POWER10 specific repo to it's own repo

### DIFF
--- a/resources/openstack.rb
+++ b/resources/openstack.rb
@@ -17,9 +17,9 @@ action :add do
   end
 
   # NOTE: Only needed on POWER10
-  yum_repository 'OSL-openstack' do
-    description "OpenStack OSL #{new_resource.version}"
-    baseurl "https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/openstack-#{new_resource.version}/$basearch"
+  yum_repository 'OSL-openstack-power10' do
+    description "OpenStack OSL #{new_resource.version} - POWER10"
+    baseurl "https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/openstack-#{new_resource.version}-power10/$basearch"
     gpgkey 'https://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl'
     priority '10'
     options(module_hotfixes: '1')

--- a/spec/unit/recipes/openstack_spec.rb
+++ b/spec/unit/recipes/openstack_spec.rb
@@ -47,7 +47,7 @@ describe 'osl-repos-test::openstack' do
             gpgkey: 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Cloud'
           )
         end
-        it { is_expected.to_not create_yum_repository 'OSL-openstack' }
+        it { is_expected.to_not create_yum_repository 'OSL-openstack-power10' }
       end
 
       %w(aarch64 ppc64le).each do |arch|
@@ -92,9 +92,9 @@ describe 'osl-repos-test::openstack' do
         case p
         when ALMA_9
           it do
-            is_expected.to create_yum_repository('OSL-openstack').with(
-              description: 'OpenStack OSL yoga',
-              baseurl: 'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/openstack-yoga/$basearch',
+            is_expected.to create_yum_repository('OSL-openstack-power10').with(
+              description: 'OpenStack OSL yoga - POWER10',
+              baseurl: 'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/openstack-yoga-power10/$basearch',
               gpgkey: 'https://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl',
               priority: '10',
               options: { module_hotfixes: '1' }
@@ -102,9 +102,9 @@ describe 'osl-repos-test::openstack' do
           end
         when ALMA_8
           it do
-            is_expected.to create_yum_repository('OSL-openstack').with(
-              description: 'OpenStack OSL train',
-              baseurl: 'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/openstack-train/$basearch',
+            is_expected.to create_yum_repository('OSL-openstack-power10').with(
+              description: 'OpenStack OSL train - POWER10',
+              baseurl: 'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/openstack-train-power10/$basearch',
               gpgkey: 'https://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl',
               priority: '10',
               options: { module_hotfixes: '1' }


### PR DESCRIPTION
Allow us to use the regular name for packages we need globally.

Signed-off-by: Lance Albertson <lance@osuosl.org>
