### PR TITLE
Clean up debian recipe for trixie release

### DIFF
--- a/kitchen.openstack.yml
+++ b/kitchen.openstack.yml
@@ -43,6 +43,12 @@ platforms:
       image_ref: "Debian 12"
     transport:
       username: debian
+  - name: debian-13
+    driver_plugin: openstack
+    driver_config:
+      image_ref: "Debian 13"
+    transport:
+      username: debian
   - name: ubuntu-24.04
     driver_plugin: openstack
     driver_config:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -9,8 +9,7 @@ transport:
   name: rsync
 
 provisioner:
-  name: chef_infra
-  product_name: cinc
+  name: cinc_infra
   product_version: '18'
   enforce_idempotency: true
   multiple_converge: 2

--- a/recipes/alma.rb
+++ b/recipes/alma.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos
 # Recipe:: alma
 #
-# Copyright:: 2020-2025, Oregon State University
+# Copyright:: 2020-2026, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/debian.rb
+++ b/recipes/debian.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos
 # Recipe:: debian
 #
-# Copyright:: 2024-2025, Oregon State University
+# Copyright:: 2024-2026, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO: this should be removed once Chef supports deb822 repo source files
+# The Debian installer drops a deb822 sources file at /etc/apt/sources.list.d/debian.sources
+# which would conflict with the legacy /etc/apt/sources.list we manage below.
 execute 'remove deb822 sources file' do
   command 'rm -f /etc/apt/sources.list.d/*.sources'
   not_if { Dir.glob('/etc/apt/sources.list.d/*.sources').empty? }
@@ -30,11 +31,6 @@ template '/etc/apt/sources.list' do
   source 'debian.sources.list.erb'
   notifies :update, 'apt_update[update]', :immediately
 end
-
-# TODO: Needed since trixie is still under testing
-file '/etc/apt/apt.conf.d/99osuosl' do
-  content 'APT::Default-Release "trixie";'
-end if node['lsb']['codename'] == 'trixie'
 
 package %w(unattended-upgrades apt-listchanges)
 

--- a/recipes/elevate.rb
+++ b/recipes/elevate.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos
 # Recipe:: elevate
 #
-# Copyright:: 2023-2025, Oregon State University
+# Copyright:: 2023-2026, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/elrepo.rb
+++ b/recipes/elrepo.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos
 # Recipe:: elrepo
 #
-# Copyright:: 2020-2025, Oregon State University
+# Copyright:: 2020-2026, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/epel.rb
+++ b/recipes/epel.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos
 # Recipe:: epel
 #
-# Copyright:: 2020-2025, Oregon State University
+# Copyright:: 2020-2026, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/hashicorp.rb
+++ b/recipes/hashicorp.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos
 # Recipe:: hashicorp
 #
-# Copyright:: 2023-2025, Oregon State University
+# Copyright:: 2023-2026, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/openstack.rb
+++ b/recipes/openstack.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos
 # Recipe:: openstack
 #
-# Copyright:: 2023-2025, Oregon State University
+# Copyright:: 2023-2026, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/oslrepo.rb
+++ b/recipes/oslrepo.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos
 # Recipe:: oslrepo
 #
-# Copyright:: 2022-2025, Oregon State University
+# Copyright:: 2022-2026, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/recipes/alma_spec.rb
+++ b/spec/unit/recipes/alma_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos
 # Spec:: default
 #
-# Copyright:: 2020-2025, Oregon State University
+# Copyright:: 2020-2026, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/recipes/centos_kmods_spec.rb
+++ b/spec/unit/recipes/centos_kmods_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos
 # Spec:: centos_kmods
 #
-# Copyright:: 2024-2025, Oregon State University
+# Copyright:: 2024-2026, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/recipes/debian_spec.rb
+++ b/spec/unit/recipes/debian_spec.rb
@@ -1,11 +1,13 @@
 require_relative '../../spec_helper'
 
 describe 'osl-repos::debian' do
-  [DEBIAN_12].each do |p|
+  [DEBIAN_12, DEBIAN_13].each do |p|
     context "#{p[:platform]} #{p[:version]}" do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(p).converge(described_recipe)
       end
+
+      codename = p[:version] == '12' ? 'bookworm' : 'trixie'
 
       before do
         allow(Dir).to receive(:glob).and_call_original
@@ -28,10 +30,10 @@ describe 'osl-repos::debian' do
         is_expected.to render_file('/etc/apt/sources.list').with_content(
             <<~EOF
               # sources.list file written by Chef
-              deb https://debian.osuosl.org/debian bookworm main non-free non-free-firmware contrib
-              deb https://debian.osuosl.org/debian bookworm-updates main non-free non-free-firmware contrib
-              deb https://debian.osuosl.org/debian bookworm-backports main non-free non-free-firmware contrib
-              deb https://deb.debian.org/debian-security bookworm-security main non-free non-free-firmware contrib
+              deb https://debian.osuosl.org/debian #{codename} main non-free non-free-firmware contrib
+              deb https://debian.osuosl.org/debian #{codename}-updates main non-free non-free-firmware contrib
+              deb https://debian.osuosl.org/debian #{codename}-backports main non-free non-free-firmware contrib
+              deb https://deb.debian.org/debian-security #{codename}-security main non-free non-free-firmware contrib
             EOF
           )
       end
@@ -52,27 +54,6 @@ describe 'osl-repos::debian' do
       it { is_expected.to start_service 'unattended-upgrades.service' }
       it { is_expected.to enable_service 'apt-daily-upgrade.timer' }
       it { is_expected.to start_service 'apt-daily-upgrade.timer' }
-
-      context 'trixie' do
-        cached(:chef_run) do
-          ChefSpec::SoloRunner.new(p) do |node|
-            node.automatic['lsb']['codename'] = 'trixie'
-          end.converge(described_recipe)
-        end
-        it do
-          is_expected.to render_file('/etc/apt/sources.list').with_content(
-              <<~EOF
-                # sources.list file written by Chef
-                deb https://debian.osuosl.org/debian trixie main non-free non-free-firmware contrib
-                deb https://debian.osuosl.org/debian trixie-updates main non-free non-free-firmware contrib
-                deb https://debian.osuosl.org/debian trixie-backports main non-free non-free-firmware contrib
-              EOF
-            )
-        end
-        it do
-          is_expected.to create_file('/etc/apt/apt.conf.d/99osuosl').with(content: 'APT::Default-Release "trixie";')
-        end
-      end
     end
   end
 end

--- a/spec/unit/recipes/disable_spec.rb
+++ b/spec/unit/recipes/disable_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos-test
 # Spec:: disable
 #
-# Copyright:: 2020-2025, Oregon State University
+# Copyright:: 2020-2026, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/recipes/elevate_spec.rb
+++ b/spec/unit/recipes/elevate_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos
 # Spec:: elevate
 #
-# Copyright:: 2023-2025, Oregon State University
+# Copyright:: 2023-2026, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/recipes/elrepo_spec.rb
+++ b/spec/unit/recipes/elrepo_spec.rb
@@ -1,7 +1,7 @@
 # Cookbook:: osl-repos
 # Spec:: elrepo
 #
-# Copyright:: 2020-2025, Oregon State University
+# Copyright:: 2020-2026, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/recipes/epel_spec.rb
+++ b/spec/unit/recipes/epel_spec.rb
@@ -1,7 +1,7 @@
 # Cookbook:: osl-repos
 # Spec:: epel
 #
-# Copyright:: 2020-2025, Oregon State University
+# Copyright:: 2020-2026, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/recipes/hashicorp_spec.rb
+++ b/spec/unit/recipes/hashicorp_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos
 # Spec:: hashicorp
 #
-# Copyright:: 2023-2025, Oregon State University
+# Copyright:: 2023-2026, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/recipes/highavailability_spec.rb
+++ b/spec/unit/recipes/highavailability_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos-test
 # Spec:: highavailability
 #
-# Copyright:: 2020-2025, Oregon State University
+# Copyright:: 2020-2026, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/recipes/openstack_spec.rb
+++ b/spec/unit/recipes/openstack_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos
 # Spec:: elevate
 #
-# Copyright:: 2023-2025, Oregon State University
+# Copyright:: 2023-2026, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/recipes/oslrepo_spec.rb
+++ b/spec/unit/recipes/oslrepo_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos
 # Spec:: oslrepo
 #
-# Copyright:: 2022-2025, Oregon State University
+# Copyright:: 2022-2026, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/recipes/with_edit_spec.rb
+++ b/spec/unit/recipes/with_edit_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos-test
 # Spec:: with_edit
 #
-# Copyright:: 2020-2025, Oregon State University
+# Copyright:: 2020-2026, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/debian.sources.list.erb
+++ b/templates/debian.sources.list.erb
@@ -2,6 +2,4 @@
 deb https://debian.osuosl.org/debian <%= node['lsb']['codename'] %> main non-free non-free-firmware contrib
 deb https://debian.osuosl.org/debian <%= node['lsb']['codename'] %>-updates main non-free non-free-firmware contrib
 deb https://debian.osuosl.org/debian <%= node['lsb']['codename'] %>-backports main non-free non-free-firmware contrib
-<% unless node['lsb']['codename'] == 'trixie' -%>
 deb https://deb.debian.org/debian-security <%= node['lsb']['codename'] %>-security main non-free non-free-firmware contrib
-<% end -%>

--- a/test/cookbooks/osl-repos-test/recipes/disable.rb
+++ b/test/cookbooks/osl-repos-test/recipes/disable.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos
 # Recipe:: disable
 #
-# Copyright:: 2020-2025, Oregon State University
+# Copyright:: 2020-2026, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/cookbooks/osl-repos-test/recipes/highavailability.rb
+++ b/test/cookbooks/osl-repos-test/recipes/highavailability.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos
 # Recipe:: highavailability
 #
-# Copyright:: 2020-2025, Oregon State University
+# Copyright:: 2020-2026, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/cookbooks/osl-repos-test/recipes/with_edit.rb
+++ b/test/cookbooks/osl-repos-test/recipes/with_edit.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-repos
 # Recipe:: with_edit
 #
-# Copyright:: 2020-2025, Oregon State University
+# Copyright:: 2020-2026, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/integration/debian/controls/debian.rb
+++ b/test/integration/debian/controls/debian.rb
@@ -1,31 +1,26 @@
 control 'debian' do
   release_name =
-  case os.release.to_i
-  when 12
-    'bookworm'
-  when 13
-    'trixie'
-  end
+    case os.release.to_i
+    when 12
+      'bookworm'
+    when 13
+      'trixie'
+    end
 
   expected_sources = [
-        '# sources.list file written by Chef',
-        "deb https://debian.osuosl.org/debian #{release_name} main non-free non-free-firmware contrib",
-        "deb https://debian.osuosl.org/debian #{release_name}-updates main non-free non-free-firmware contrib",
-        "deb https://debian.osuosl.org/debian #{release_name}-backports main non-free non-free-firmware contrib",
+    '# sources.list file written by Chef',
+    "deb https://debian.osuosl.org/debian #{release_name} main non-free non-free-firmware contrib",
+    "deb https://debian.osuosl.org/debian #{release_name}-updates main non-free non-free-firmware contrib",
+    "deb https://debian.osuosl.org/debian #{release_name}-backports main non-free non-free-firmware contrib",
+    "deb https://deb.debian.org/debian-security #{release_name}-security main non-free non-free-firmware contrib",
   ]
-
-  if os.release.to_i == 12
-    expected_sources << "deb https://deb.debian.org/debian-security #{release_name}-security main non-free non-free-firmware contrib"
-  end
 
   describe file '/etc/apt/sources.list' do
     its('content') { should cmp expected_sources.join("\n") + "\n" }
   end
 
-  if os.release.to_i == 12
-    describe file '/etc/apt/apt.conf.d/99osuosl' do
-      it { should_not exist }
-    end
+  describe file '/etc/apt/apt.conf.d/99osuosl' do
+    it { should_not exist }
   end
 
   %w(


### PR DESCRIPTION
- Drop the trixie-pinning 99osuosl workaround now that trixie is released
- Add the debian-security archive for trixie (now exists)
- Reword the deb822 cleanup comment to reflect that the Debian installer is what
  drops the .sources file, not a Chef gap
- Add debian-13 platform to kitchen.openstack.yml
- Switch kitchen.yml provisioner to cinc_infra
- Cookstyle fixups and copyright bumps to 2026
- Update chefspec to cover both DEBIAN_12 and DEBIAN_13
- Update debian inspec controls to expect debian-security on trixie

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
