### PR TITLE
Bump yum-almalinux to 3.1.0 and add testing/nvidia repos

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ chef_version      '>= 16.0'
 version           '5.11.1'
 
 depends           'yum',           '~> 7.4.13'
-depends           'yum-almalinux', '~> 1.2.0'
+depends           'yum-almalinux', '~> 3.1.0'
 depends           'yum-epel',      '~> 5.0.0'
 depends           'yum-elrepo',    '~> 2.4.0'
 

--- a/resources/alma.rb
+++ b/resources/alma.rb
@@ -11,6 +11,8 @@ property :appstream, [true, false], default: true
 property :powertools, [true, false], default: true
 property :highavailability, [true, false], default: false
 property :synergy, [true, false], default: false
+property :testing, [true, false], default: false
+property :nvidia, [true, false], default: false
 property :exclude, Array, default: []
 
 action :add do
@@ -68,5 +70,17 @@ action :add do
     baseurl "#{alma_url}/#{release_var}/synergy/$basearch/os/"
     extra_options passthrough
     enabled new_resource.synergy
+  end
+
+  yum_alma_testing 'default' do
+    extra_options passthrough
+    enabled new_resource.testing
+  end
+
+  if new_resource.nvidia
+    yum_alma_nvidia 'default' do
+      extra_options passthrough
+      enabled new_resource.nvidia
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,6 +60,8 @@ ALL_RESOURCES = [
   :yum_alma_ha,
   :yum_alma_powertools,
   :yum_alma_synergy,
+  :yum_alma_testing,
+  :yum_alma_nvidia,
 ].freeze
 
 ALMA_RESOURCES = [
@@ -70,6 +72,8 @@ ALMA_RESOURCES = [
   :yum_alma_ha,
   :yum_alma_powertools,
   :yum_alma_synergy,
+  :yum_alma_testing,
+  :yum_alma_nvidia,
 ].freeze
 
 RSpec.configure do |config|

--- a/spec/unit/recipes/alma_spec.rb
+++ b/spec/unit/recipes/alma_spec.rb
@@ -106,6 +106,20 @@ describe 'osl-repos::alma' do
             )
           end
 
+          # Test the testing repository (disabled by default; baseurl from
+          # upstream yum-almalinux defaults to vault.almalinux.org)
+          it do
+            expect(chef_run).to create_yum_repository('testing').with(
+              baseurl: "https://vault.almalinux.org/#{p[:version].to_i}/testing/$basearch/os/",
+              enabled: false
+            )
+          end
+
+          # The nvidia repo is only wired up when the nvidia property is
+          # explicitly set to true (the resource itself installs a release
+          # package, so we don't want it running on hosts that don't need it).
+          it { expect(chef_run).not_to create_yum_repository('nvidia') }
+
           # Test the powertools repository
           power_tools = p[:version].to_i >= 9 ? 'CRB' : 'PowerTools'
           it do

--- a/test/integration/alma/inspec/alma_spec.rb
+++ b/test/integration/alma/inspec/alma_spec.rb
@@ -44,6 +44,19 @@ describe yum.repo('synergy') do
   its('mirrors') { should eq nil }
 end
 
+describe yum.repo('testing') do
+  it { should exist }
+  it { should_not be_enabled }
+  its('baseurl') { should eq "https://vault.almalinux.org/#{rel}/testing/x86_64/os/" }
+  its('mirrors') { should eq nil }
+end
+
+# nvidia is off by default and the resource is only declared when the
+# nvidia property is true, so the repo file should not be present.
+describe yum.repo('nvidia') do
+  it { should_not exist }
+end
+
 describe yum.repo(power_tools.downcase) do
   it { should exist }
   it { should be_enabled }


### PR DESCRIPTION
Updates the yum-almalinux dependency from ~> 1.2.0 to ~> 3.1.0 and
wires up the new yum_alma_testing and yum_alma_nvidia resources on
the osl_repos_alma resource. The testing repo lets us enable the
AlmaLinux testing repo when fixes haven't landed in the primary repo
yet. Both default to disabled; the nvidia block is only declared when
the property is true so the upstream release-package install does not
run on hosts that don't need it.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
